### PR TITLE
Update sitemap and add sitemap test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # conde86labs.github.io
+
+## Running Tests
+
+This repository includes a small test suite powered by `pytest`.
+
+1. Install the test dependencies (only `pytest` is required):
+
+   ```bash
+   pip install pytest
+   ```
+
+2. Execute the tests from the repository root:
+
+   ```bash
+   pytest
+   ```

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,4 +11,14 @@
   <lastmod>2024-08-24T04:14:26+00:00</lastmod>
 </url>
 
+<url>
+  <loc>https://conde86projects.github.io/conde86labs.github.io/apoie.html</loc>
+  <lastmod>2024-08-24T04:14:26+00:00</lastmod>
+</url>
+
+<url>
+  <loc>https://conde86projects.github.io/conde86labs.github.io/politica-de-privacidade.html</loc>
+  <lastmod>2024-08-24T04:14:26+00:00</lastmod>
+</url>
+
 </urlset>

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,10 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+def test_sitemap_contains_pages():
+    sitemap_path = Path(__file__).resolve().parents[1] / "sitemap.xml"
+    tree = ET.parse(sitemap_path)
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    locs = [elem.text for elem in tree.findall(".//sm:loc", ns)]
+    assert "https://conde86projects.github.io/conde86labs.github.io/apoie.html" in locs
+    assert "https://conde86projects.github.io/conde86labs.github.io/politica-de-privacidade.html" in locs


### PR DESCRIPTION
## Summary
- list the support and privacy pages in `sitemap.xml`
- add a simple sitemap test
- document how to run the tests with `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f88c119d88328b32bb7be54c7c683